### PR TITLE
修复开发环境启动脚本报错问题

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -14,11 +14,11 @@ from biz.applications import Application as CmdbApp
 from biz.crontab_app import Application as CronApp
 
 
-define("service", default='api', help="start service flag", type=str)
+define("service", default='api', help="start service flag", type=bool)
 
 
 class MyProgram(MainProgram):
-    def __init__(self, service='cmdb_api', progress_id='cmdb'):
+    def __init__(self, service, progress_id):
         self.__app = None
         settings = app_settings
         if service == 'cmdb':
@@ -30,4 +30,5 @@ class MyProgram(MainProgram):
 
 
 if __name__ == '__main__':
+    # 启动 python3 startup.py --service cmdb --progressid 'cmdb'
     fire.Fire(MyProgram)


### PR DESCRIPTION
1.参数类型错误，应该为bool类型。字符产类型tornado内部报错，无法启动
2.fire无法识别有默认参数的传值